### PR TITLE
Update themes_for_rails.gemspec

### DIFF
--- a/themes_for_rails.gemspec
+++ b/themes_for_rails.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit"
   gem.add_development_dependency "contest"
   gem.add_development_dependency "mocha"
-  gem.add_development_dependency('rails', ["= 3.0.11"])
 end


### PR DESCRIPTION
I get the error: 

<pre>
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on rails (= 3.0.11, development), (>= 3.0.0) use:
    add_runtime_dependency 'rails', '= 3.0.11', '>= 3.0.0'
</pre>


in bundler 1.9.9 is a warning/notice but bundler 1.10.3 makes it fatal
